### PR TITLE
Fixed `nested` scheme

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,9 +33,9 @@ module.exports = function (levels, options) {
     function scan(level, callback) {
         var step = level.scheme(level.path, level.naming);
 
-        walk(level.path, null, callback);
+        walk(level.path, 1, null, callback);
 
-        function walk(dir, data, callback) {
+        function walk(dir, depth, data, callback) {
             fs.readdir(dir, function (err, items) {
                 if (err) return callback(err);
 
@@ -50,12 +50,13 @@ module.exports = function (levels, options) {
                         basename: basename,
                         dirname: dir,
                         filename: filename,
+                        depth: depth,
                         data: data
                     }, add, deepWalk, next);
                 }
 
                 function deepWalk(dir, data) {
-                    walk(dir, data, next);
+                    walk(dir, depth + 1, data, next);
                 }
 
                 function next(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,9 +33,9 @@ module.exports = function (levels, options) {
     function scan(level, callback) {
         var step = level.scheme(level.path, level.naming);
 
-        walk(level.path, callback);
+        walk(level.path, null, callback);
 
-        function walk(dir, callback) {
+        function walk(dir, data, callback) {
             fs.readdir(dir, function (err, items) {
                 if (err) return callback(err);
 
@@ -49,12 +49,13 @@ module.exports = function (levels, options) {
                     step({
                         basename: basename,
                         dirname: dir,
-                        filename: filename
+                        filename: filename,
+                        data: data
                     }, add, deepWalk, next);
                 }
 
-                function deepWalk(dir) {
-                    walk(dir, next);
+                function deepWalk(dir, data) {
+                    walk(dir, data, next);
                 }
 
                 function next(err) {

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -1,11 +1,10 @@
-var path = require('path'),
-    sep = path.sep;
+var path = require('path');
 
 module.exports = function (level, naming) {
     return function (item, add, walk, next) {
         var basename = item.basename,
             filename = item.filename,
-            depth = filename.split(sep).length - level.split(sep).length,
+            depth = item.depth,
             splited = basename.split('.'),
             dirNotation, dirType;
 

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -5,29 +5,66 @@ module.exports = function (level, naming) {
     return function (item, add, walk, next) {
         var basename = item.basename,
             filename = item.filename,
-            parent = path.basename(item.dirname),
-            grandParent = path.basename(path.dirname(item.dirname)),
-            depth = filename.split(sep).length - level.split(sep).length;
+            depth = filename.split(sep).length - level.split(sep).length,
+            splited = basename.split('.'),
+            dirNotation, dirType;
 
-        if ((depth === 1 && naming.isBlock(basename)) ||
-            (depth === 2 && naming.isBlockMod(parent + basename)) ||
-            (depth === 2 && naming.isElem(parent + basename)) ||
-            (depth === 3 && naming.isElemMod(grandParent + parent + basename))
-        ) {
-            return walk(filename);
-        }
+        if (splited.length === 1) {
+            var dirname = item.dirname,
+                parent;
 
-        var splited = basename.split('.'),
-            bemname = splited.shift(),
-            notation = naming.parse(bemname),
-            tech =  splited.join('.');
+            if (depth === 1) {
+                dirNotation = naming.parse(basename);
+                dirType = naming.typeOf(dirNotation);
 
-        if (notation && tech) {
-            notation.level = level;
-            notation.tech = tech;
-            notation.path = filename;
+                if (dirType === 'block') {
+                    return walk(filename, { notation: dirNotation, type: dirType });
+                }
+            } else if (depth === 2) {
+                parent = path.basename(dirname);
+                dirNotation = naming.parse(parent + basename);
+                dirType = naming.typeOf(dirNotation);
 
-            add(notation);
+                if (dirType === 'blockMod' || dirType === 'elem') {
+                    return walk(filename, { notation: dirNotation, type: dirType });
+                }
+            } else if (depth === 3) {
+                var grandParent = path.basename(path.dirname(dirname));
+
+                parent = path.basename(dirname);
+                dirNotation = naming.parse(grandParent + parent + basename);
+                dirType = naming.typeOf(dirNotation);
+
+                if (dirType === 'elemMod') {
+                    return walk(filename, { notation: dirNotation, type: dirType });
+                }
+            }
+        } else {
+            if (depth > 1) {
+                var data = item.data,
+                    bemname = splited.shift(),
+                    tech = splited.join('.'),
+                    notation = naming.parse(bemname);
+
+                dirNotation = data.notation;
+                dirType = data.type;
+
+                if (notation &&
+                    (depth === 2 && dirNotation.block === notation.block) ||
+                    (depth === 3 && dirType === 'elem' && dirNotation.block === notation.block &&
+                        dirNotation.elem === notation.elem) ||
+                    (depth === 3 && dirType === 'blockMod' && dirNotation.block === notation.block &&
+                        dirNotation.modName === notation.modName) ||
+                    (depth === 4 && dirNotation.block === notation.block && dirNotation.elem === notation.elem &&
+                        dirNotation.modName === notation.modName)
+                ) {
+                    notation.level = level;
+                    notation.tech = tech;
+                    notation.path = filename;
+
+                    add(notation);
+                }
+            }
         }
 
         next();

--- a/test/schemes/nested.test.js
+++ b/test/schemes/nested.test.js
@@ -161,6 +161,81 @@ describe('nested scheme', function () {
         }], done);
     });
 
+    it('must detect complex entities', function (done) {
+        mock({
+            blocks: {
+                block: {
+                    'block.ext': '',
+                    '_bool-mod': {
+                        'block_bool-mod.ext': ''
+                    },
+                    _mod: {
+                        'block_mod_val.ext': ''
+                    },
+                    __elem: {
+                        'block__elem.ext': '',
+                        '_bool-mod': {
+                            'block__elem_bool-mod.ext': ''
+                        },
+                        _mod: {
+                            'block__elem_mod_val.ext': ''
+                        }
+                    }
+                }
+            }
+        });
+
+        assert(['blocks'], opts, [
+            {
+                block: 'block',
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', 'block.ext')
+            },
+            {
+                block: 'block',
+                elem: 'elem',
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', '__elem', 'block__elem.ext')
+            },
+            {
+                block: 'block',
+                modName: 'bool-mod',
+                modVal: true,
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', '_bool-mod', 'block_bool-mod.ext')
+            },
+            {
+                block: 'block',
+                modName: 'mod',
+                modVal: 'val',
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', '_mod', 'block_mod_val.ext')
+            },
+            {
+                block: 'block',
+                elem: 'elem',
+                modName: 'bool-mod',
+                modVal: true,
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', '__elem', '_bool-mod', 'block__elem_bool-mod.ext')
+            },
+            {
+                block: 'block',
+                elem: 'elem',
+                modName: 'mod',
+                modVal: 'val',
+                tech: 'ext',
+                level: 'blocks',
+                path: path.join('blocks', 'block', '__elem', '_mod', 'block__elem_mod_val.ext')
+            }
+        ], done);
+    });
+
     it('must detect block in few levels', function (done) {
         mock({
             'common.blocks': {
@@ -189,5 +264,71 @@ describe('nested scheme', function () {
                 tech: 'ext'
             }
         ], done);
+    });
+
+    it('must not detect file in root of level', function (done) {
+        mock({
+            blocks: {
+                'block.ext': ''
+            }
+        });
+
+        assert(['blocks'], opts, [], done);
+    });
+
+    it('must not detect block if filename not match with dirname', function (done) {
+        mock({
+            blocks: {
+                block: {
+                    'other-block.ext': ''
+                }
+            }
+        });
+
+        assert(['blocks'], opts, [], done);
+    });
+
+    it('must not detect elem if filename not match with dirname', function (done) {
+        mock({
+            blocks: {
+                block: {
+                    _mod: {
+                        'block_other-mod.ext': ''
+                    }
+                }
+            }
+        });
+
+        assert(['blocks'], opts, [], done);
+    });
+
+    it('must not detect mod if filename not match with dirname', function (done) {
+        mock({
+            blocks: {
+                block: {
+                    __elem: {
+                        'block__other-elem.ext': ''
+                    }
+                }
+            }
+        });
+
+        assert(['blocks'], opts, [], done);
+    });
+
+    it('must not detect elem mod if filename not match with dirname', function (done) {
+        mock({
+            blocks: {
+                block: {
+                    __elem: {
+                        _mod: {
+                            'block__elem_other-mod.ext': ''
+                        }
+                    }
+                }
+            }
+        });
+
+        assert(['blocks'], opts, [], done);
     });
 });


### PR DESCRIPTION
* Fixed scheme: ignore some files if name of BEM-entity not match with parent dirnames (see tests).
* Accelerated the walk.

### Benchmarks

before:

```
           1,132 op/s » nested level
              53 op/s » `bem-bl`
              32 op/s » `bem-core` + `bem-components`
              18 op/s » `bem-bl` + `bem-core` + `bem-components`
```

after: 
```
            bem-walk
           2,717 op/s » nested level
             147 op/s » `bem-bl`
              99 op/s » `bem-core` + `bem-components`
              59 op/s » `bem-bl` + `bem-core` + `bem-components`
```

Third-party:
```
                      enb
           2,662 op/s » nested level
              71 op/s » `bem-bl`
              50 op/s » `bem-core` + `bem-components`
              29 op/s » `bem-bl` + `bem-core` + `bem-components`

                      scan-level
           2,972 op/s » nested level
              77 op/s » `bem-bl`
              52 op/s » `bem-core` + `bem-components`
              30 op/s » `bem-bl` + `bem-core` + `bem-components`
```